### PR TITLE
Apply the custom baseline via systemprep formula

### DIFF
--- a/windows/salt/srv/pillar/systemprep.sls
+++ b/windows/salt/srv/pillar/systemprep.sls
@@ -21,6 +21,7 @@ systemprep:
     - ash-windows.iavm
   post-states:
     - ash-windows.delta
+    - ash-windows.custom
     - scc.scan
 
 ash-windows:


### PR DESCRIPTION
Depends on the ash-windows rewrite that includes the new `custom`
baseline.