### PR TITLE
Explicitly marks winrepo package versions as strings

### DIFF
--- a/windows/salt/srv/winrepo/winrepo/dotnet_pkg/init.sls
+++ b/windows/salt/srv/winrepo/winrepo/dotnet_pkg/init.sls
@@ -78,6 +78,6 @@ the `package.common_params` dictionary.
       package.pillar ~ ':common_params',
       default=package.common_params,
       merge=True)) %}
-  {{ version }}:
+  '{{ version }}':
     {{ params }}
   {%- endfor %}

--- a/windows/salt/srv/winrepo/winrepo/emet_pkg/init.sls
+++ b/windows/salt/srv/winrepo/winrepo/emet_pkg/init.sls
@@ -59,6 +59,6 @@ the `package.common_params` dictionary.
       package.pillar ~ ':common_params',
       default=package.common_params,
       merge=True)) %}
-  {{ version }}:
+  '{{ version }}':
     {{ params }}
   {%- endfor %}

--- a/windows/salt/srv/winrepo/winrepo/mcafee_agent_pkg/init.sls
+++ b/windows/salt/srv/winrepo/winrepo/mcafee_agent_pkg/init.sls
@@ -55,6 +55,6 @@ the `package.common_params` dictionary.
       package.pillar ~ ':common_params',
       default=package.common_params,
       merge=True)) %}
-  {{ version }}:
+  '{{ version }}':
     {{ params }}
   {%- endfor %}

--- a/windows/salt/srv/winrepo/winrepo/netbanner_pkg/init.sls
+++ b/windows/salt/srv/winrepo/winrepo/netbanner_pkg/init.sls
@@ -69,6 +69,6 @@ the `package.common_params` dictionary.
       package.pillar ~ ':common_params',
       default=package.common_params,
       merge=True)) %}
-  {{ version }}:
+  '{{ version }}':
     {{ params }}
   {%- endfor %}

--- a/windows/salt/srv/winrepo/winrepo/scc_pkg/init.sls
+++ b/windows/salt/srv/winrepo/winrepo/scc_pkg/init.sls
@@ -57,6 +57,6 @@ the `package.common_params` dictionary.
       package.pillar ~ ':common_params',
       default=package.common_params,
       merge=True)) %}
-  {{ version }}:
+  '{{ version }}':
     {{ params }}
   {%- endfor %}

--- a/windows/salt/srv/winrepo/winrepo/splunkforwarder_pkg/init.sls
+++ b/windows/salt/srv/winrepo/winrepo/splunkforwarder_pkg/init.sls
@@ -57,6 +57,6 @@ the `package.common_params` dictionary.
       package.pillar ~ ':common_params',
       default=package.common_params,
       merge=True)) %}
-  {{ version }}:
+  '{{ version }}':
     {{ params }}
   {%- endfor %}


### PR DESCRIPTION
Salt 2016.11 will not load winrepo packages if the version is not
a string, and yaml will typically interpret numbers as integers or
floats.

Wrapping the version in quotes ensures yaml will interpret the versions
as strings.